### PR TITLE
Add support for multi-user credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,19 @@ or with custom credentials
 docker run --restart always -d --name telegram-proxy -e SOCKS_USER=telegram -e SOCKS_PASSWORD=telegram -p 1080:1080 ex3ndr/telegram-proxy
 ```
 
+or with custom multi-user credentials stored in JSON file
+```
+docker run --restart always -d --name telegram-proxy -v ~/socks-credentials.json:/credentials.json -e SOCKS_CREDENTIALS_FILE=/credentials.json -p 1080:1080 ex3ndr/telegram-proxy
+```
+Sample `credentials.json`:
+```
+{
+  "user1": "password1",
+  "user2": "password2",
+  "user3": "password3"
+}
+```
+
 or if you want to allow only specific ip addresses as destination for proxy
 ```
 docker run --restart always -d --name telegram-proxy -e "SOCKS_WHITELIST=8.8.8.8,8.8.4.4,8.8.8.0/22" -p 1080:1080 ex3ndr/telegram-proxy


### PR DESCRIPTION
If I share my username/password pair to a large number of people, my credentials can fall into the hands of unscrupulous users (e.g. spammers). In such situation I will have to reset password for all of conscientious users. On the contrary, if I will set up individual credential for each group of the people, not all of them will be affected.

This PR provides basic support of multi-user configuration with username-password pairs stored in JSON file.